### PR TITLE
perf(ng-prism): shared ts.Program eliminates N× memory in multi-entry scanning

### DIFF
--- a/packages/ng-prism/src/builder/scanner/__fixtures__/entry-a.ts
+++ b/packages/ng-prism/src/builder/scanner/__fixtures__/entry-a.ts
@@ -1,0 +1,1 @@
+export { ButtonComponent } from './button.component.js';

--- a/packages/ng-prism/src/builder/scanner/__fixtures__/entry-b.ts
+++ b/packages/ng-prism/src/builder/scanner/__fixtures__/entry-b.ts
@@ -1,0 +1,1 @@
+export { ButtonComponent } from './button.component.js';

--- a/packages/ng-prism/src/builder/scanner/component.scanner.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/component.scanner.spec.ts
@@ -19,10 +19,13 @@ describe('scanComponents', () => {
   let exports: ts.Symbol[];
 
   beforeAll(() => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const result = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const result = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
     checker = result.program.getTypeChecker();
-    exports = result.exports;
+    exports = result.entries[0].exports;
   });
 
   it('should find only @Showcase-annotated components', () => {

--- a/packages/ng-prism/src/builder/scanner/component.scanner.ts
+++ b/packages/ng-prism/src/builder/scanner/component.scanner.ts
@@ -32,6 +32,11 @@ export function scanComponents(
     const classDecl = resolved.declarations?.find(ts.isClassDeclaration);
     if (!classDecl) continue;
 
+    // Perf: cheap pre-filter — skip the full decorator walk for files that don't
+    // mention Showcase at all. False positives (string-literal containing "@Showcase")
+    // just lose the optimization for that file; correctness is unaffected.
+    if (!classDecl.getSourceFile().text.includes('@Showcase')) continue;
+
     const showcaseDecorator = findDecorator(classDecl, 'Showcase');
     if (!showcaseDecorator) continue;
 

--- a/packages/ng-prism/src/builder/scanner/entry-point.scanner.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/entry-point.scanner.spec.ts
@@ -15,9 +15,12 @@ const compilerOptions: ts.CompilerOptions = {
 
 describe('resolveEntryPointExports', () => {
   it('should resolve all exports from public-api.ts', () => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const { exports } = resolveEntryPointExports(entryPoint, compilerOptions);
-    const names = exports.map((s) => s.name).sort();
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const { entries } = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
+    const names = entries[0].exports.map((s) => s.name).sort();
 
     expect(names).toEqual([
       'ButtonComponent',
@@ -32,16 +35,65 @@ describe('resolveEntryPointExports', () => {
   });
 
   it('should return a valid program', () => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const { program } = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const { program } = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
 
     expect(program).toBeDefined();
     expect(program.getTypeChecker()).toBeDefined();
   });
 
-  it('should throw for missing entry point', () => {
-    expect(() =>
-      resolveEntryPointExports('/non-existent/file.ts', compilerOptions)
-    ).toThrow('Could not find source file');
+  it('should warn and return empty exports for a missing entry point (no throw)', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const { entries } = resolveEntryPointExports(
+        [{ entryFile: '/non-existent/file.ts', importPath: 'fixture' }],
+        compilerOptions
+      );
+      expect(entries).toHaveLength(1);
+      expect(entries[0].exports).toEqual([]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('source file not found for entry point')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('should isolate per-entry failures: other entries still resolved', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+      const { entries } = resolveEntryPointExports(
+        [
+          { entryFile: '/non-existent/file.ts', importPath: 'broken' },
+          { entryFile, importPath: 'good' },
+        ],
+        compilerOptions
+      );
+      expect(entries[0].exports).toEqual([]);
+      expect(entries[1].exports.length).toBeGreaterThan(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('should resolve multiple entry points with one shared program', () => {
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const { program, entries } = resolveEntryPointExports(
+      [
+        { entryFile, importPath: 'a' },
+        { entryFile, importPath: 'b' },
+      ],
+      compilerOptions
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0].importPath).toBe('a');
+    expect(entries[1].importPath).toBe('b');
+    // both entries point at the same SourceFile instance (single shared program)
+    expect(program.getSourceFile(entryFile)).toBeDefined();
   });
 });

--- a/packages/ng-prism/src/builder/scanner/entry-point.scanner.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/entry-point.scanner.spec.ts
@@ -46,7 +46,9 @@ describe('resolveEntryPointExports', () => {
   });
 
   it('should warn and return empty exports for a missing entry point (no throw)', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     try {
       const { entries } = resolveEntryPointExports(
         [{ entryFile: '/non-existent/file.ts', importPath: 'fixture' }],
@@ -63,7 +65,9 @@ describe('resolveEntryPointExports', () => {
   });
 
   it('should isolate per-entry failures: other entries still resolved', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     try {
       const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
       const { entries } = resolveEntryPointExports(

--- a/packages/ng-prism/src/builder/scanner/entry-point.scanner.ts
+++ b/packages/ng-prism/src/builder/scanner/entry-point.scanner.ts
@@ -1,37 +1,65 @@
 import ts from 'typescript';
 
-export interface EntryPointResult {
-  program: ts.Program;
+export interface EntryPointInput {
+  entryFile: string;
+  importPath: string;
+}
+
+export interface ResolvedEntryPoint extends EntryPointInput {
   exports: ts.Symbol[];
 }
 
+export interface MultiEntryResult {
+  program: ts.Program;
+  entries: ResolvedEntryPoint[];
+}
+
 /**
- * Resolve all exported symbols from an entry-point file (e.g. public-api.ts).
+ * Resolve all exported symbols for one or more entry-point files (e.g. public-api.ts).
+ * A single shared `ts.Program` is created with every entry file as a root name, so the
+ * transitive type graph (Angular framework typings, etc.) is parsed once and reused
+ * across all entries via the shared `TypeChecker`.
+ *
  * Re-exports (`export * from '...'`) are resolved automatically by TypeScript.
  */
 export function resolveEntryPointExports(
-  entryPointPath: string,
+  entryPoints: ReadonlyArray<EntryPointInput>,
   compilerOptions: ts.CompilerOptions,
-  previousProgram?: ts.Program,
-): EntryPointResult {
+  previousProgram?: ts.Program
+): MultiEntryResult {
   const program = ts.createProgram(
-    [entryPointPath],
+    entryPoints.map((e) => e.entryFile),
     compilerOptions,
     undefined,
-    previousProgram,
+    previousProgram
   );
   const checker = program.getTypeChecker();
-  const sourceFile = program.getSourceFile(entryPointPath);
 
-  if (!sourceFile) {
-    throw new Error(`Could not find source file: ${entryPointPath}`);
-  }
+  const entries: ResolvedEntryPoint[] = entryPoints.map(
+    ({ entryFile, importPath }) => {
+      try {
+        const sourceFile = program.getSourceFile(entryFile);
+        if (!sourceFile) {
+          console.warn(
+            `⚠ ng-prism: source file not found for entry point ${entryFile}, skipping.`
+          );
+          return { entryFile, importPath, exports: [] };
+        }
+        const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
+        const exports = moduleSymbol
+          ? checker.getExportsOfModule(moduleSymbol)
+          : [];
+        return { entryFile, importPath, exports };
+      } catch (err) {
+        console.error(
+          `⚠ ng-prism: failed to resolve exports for ${entryFile}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+        return { entryFile, importPath, exports: [] };
+      }
+    }
+  );
 
-  const moduleSymbol = checker.getSymbolAtLocation(sourceFile);
-  if (!moduleSymbol) {
-    return { program, exports: [] };
-  }
-
-  const exports = checker.getExportsOfModule(moduleSymbol);
-  return { program, exports };
+  return { program, entries };
 }

--- a/packages/ng-prism/src/builder/scanner/index.ts
+++ b/packages/ng-prism/src/builder/scanner/index.ts
@@ -1,8 +1,12 @@
 // Scanner API exports
 export { createScanner } from './scanner.js';
-export type { CreateScannerOptions, Scanner } from './scanner.js';
+export type { CreateScannerOptions, Scanner, ScanResult } from './scanner.js';
 export { resolveEntryPointExports } from './entry-point.scanner.js';
-export type { EntryPointResult } from './entry-point.scanner.js';
+export type {
+  EntryPointInput,
+  ResolvedEntryPoint,
+  MultiEntryResult,
+} from './entry-point.scanner.js';
 export { scanComponents } from './component.scanner.js';
 export { extractInputs, extractOutputs } from './input.extractor.js';
 export { generateManifest } from './manifest.generator.js';

--- a/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
@@ -17,7 +17,7 @@ const compilerOptions: ts.CompilerOptions = {
 function getClassDeclaration(
   exports: ts.Symbol[],
   className: string,
-  checker: ts.TypeChecker,
+  checker: ts.TypeChecker
 ): ts.ClassDeclaration {
   let sym = exports.find((s) => s.name === className)!;
   // Resolve alias symbols (from re-exports)
@@ -141,16 +141,30 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should extract all signal inputs from SignalButtonComponent', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
 
     expect(inputs).toHaveLength(5);
     const names = inputs.map((i) => i.name);
-    expect(names).toEqual(['variant', 'label', 'disabled', 'title', 'tabIndex']);
+    expect(names).toEqual([
+      'variant',
+      'label',
+      'disabled',
+      'title',
+      'tabIndex',
+    ]);
   });
 
   it('should resolve union type from signal type argument', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const variant = inputs.find((i) => i.name === 'variant')!;
 
@@ -161,7 +175,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should infer string type from signal default value', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const label = inputs.find((i) => i.name === 'label')!;
 
@@ -171,7 +189,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should infer boolean type from signal default value', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const disabled = inputs.find((i) => i.name === 'disabled')!;
 
@@ -181,7 +203,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should mark input.required() as required with no defaultValue', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const title = inputs.find((i) => i.name === 'title')!;
 
@@ -191,7 +217,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should extract model() inputs like signal inputs', () => {
-    const classDecl = getClassDeclaration(exports, 'ModelInputComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'ModelInputComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
 
     expect(inputs).toHaveLength(2);
@@ -206,7 +236,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should resolve nullable number type (number | null) as number', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const tabIndex = inputs.find((i) => i.name === 'tabIndex')!;
 
@@ -216,7 +250,11 @@ describe('extractInputs (signal-based)', () => {
   });
 
   it('should extract JSDoc comments from signal inputs', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const inputs = extractInputs(classDecl, checker);
     const variant = inputs.find((i) => i.name === 'variant')!;
 
@@ -239,7 +277,11 @@ describe('extractOutputs (signal-based)', () => {
   });
 
   it('should extract all signal outputs from SignalButtonComponent', () => {
-    const classDecl = getClassDeclaration(exports, 'SignalButtonComponent', checker);
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
     const outputs = extractOutputs(classDecl, checker);
 
     expect(outputs).toHaveLength(2);

--- a/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
@@ -33,10 +33,13 @@ describe('extractInputs', () => {
   let exports: ts.Symbol[];
 
   beforeAll(() => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const result = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const result = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
     checker = result.program.getTypeChecker();
-    exports = result.exports;
+    exports = result.entries[0].exports;
   });
 
   it('should extract all inputs from ButtonComponent', () => {
@@ -128,10 +131,13 @@ describe('extractInputs (signal-based)', () => {
   let exports: ts.Symbol[];
 
   beforeAll(() => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const result = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const result = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
     checker = result.program.getTypeChecker();
-    exports = result.exports;
+    exports = result.entries[0].exports;
   });
 
   it('should extract all signal inputs from SignalButtonComponent', () => {
@@ -223,10 +229,13 @@ describe('extractOutputs (signal-based)', () => {
   let exports: ts.Symbol[];
 
   beforeAll(() => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const result = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const result = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
     checker = result.program.getTypeChecker();
-    exports = result.exports;
+    exports = result.entries[0].exports;
   });
 
   it('should extract all signal outputs from SignalButtonComponent', () => {
@@ -246,10 +255,13 @@ describe('extractOutputs', () => {
   let exports: ts.Symbol[];
 
   beforeAll(() => {
-    const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
-    const result = resolveEntryPointExports(entryPoint, compilerOptions);
+    const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+    const result = resolveEntryPointExports(
+      [{ entryFile, importPath: 'fixture' }],
+      compilerOptions
+    );
     checker = result.program.getTypeChecker();
-    exports = result.exports;
+    exports = result.entries[0].exports;
   });
 
   it('should extract all outputs from ButtonComponent', () => {

--- a/packages/ng-prism/src/builder/scanner/scanner.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/scanner.spec.ts
@@ -12,19 +12,20 @@ import { createScanner } from './scanner.js';
 const FIXTURES_DIR = path.join(__dirname, '__fixtures__');
 
 describe('createScanner', () => {
-  const entryPoint = path.join(FIXTURES_DIR, 'public-api.ts');
+  const entryFile = path.join(FIXTURES_DIR, 'public-api.ts');
+  const entryPoints = [{ entryFile, importPath: 'fixture' }];
 
   it('should scan the full pipeline from entry point to manifest', () => {
-    const scanner = createScanner({ entryPoint });
-    const manifest = scanner.scan();
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
 
-    expect(manifest.components).toHaveLength(6);
+    expect(result.components).toHaveLength(6);
   });
 
   it('should produce correct ButtonComponent data', () => {
-    const scanner = createScanner({ entryPoint });
-    const manifest = scanner.scan();
-    const button = manifest.components.find(
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
+    const button = result.components.find(
       (c) => c.className === 'ButtonComponent'
     )!;
 
@@ -52,9 +53,9 @@ describe('createScanner', () => {
   });
 
   it('should produce correct CardComponent data', () => {
-    const scanner = createScanner({ entryPoint });
-    const manifest = scanner.scan();
-    const card = manifest.components.find(
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
+    const card = result.components.find(
       (c) => c.className === 'CardComponent'
     )!;
 
@@ -66,27 +67,27 @@ describe('createScanner', () => {
   });
 
   it('should not include non-Showcase components', () => {
-    const scanner = createScanner({ entryPoint });
-    const manifest = scanner.scan();
-    const names = manifest.components.map((c) => c.className);
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
+    const names = result.components.map((c) => c.className);
 
     expect(names).not.toContain('NoShowcaseComponent');
   });
 
   it('should accept custom compiler options', () => {
     const scanner = createScanner({
-      entryPoint,
+      entryPoints,
       compilerOptions: { strict: false },
     });
-    const manifest = scanner.scan();
+    const result = scanner.scan();
 
-    expect(manifest.components).toHaveLength(6);
+    expect(result.components).toHaveLength(6);
   });
 
   it('should produce correct HighlightDirective data', () => {
-    const scanner = createScanner({ entryPoint });
-    const manifest = scanner.scan();
-    const highlight = manifest.components.find(
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
+    const highlight = result.components.find(
       (c) => c.className === 'HighlightDirective'
     )!;
 
@@ -99,8 +100,18 @@ describe('createScanner', () => {
     expect(highlight.outputs).toHaveLength(1);
   });
 
+  it('should tag every scanned component with its entry-point importPath', () => {
+    const scanner = createScanner({ entryPoints });
+    const result = scanner.scan();
+
+    expect(result.components.length).toBeGreaterThan(0);
+    for (const c of result.components) {
+      expect(c.importPath).toBe('fixture');
+    }
+  });
+
   it('should retain program reference across scans (previousProgram threading)', () => {
-    const scanner = createScanner({ entryPoint });
+    const scanner = createScanner({ entryPoints });
 
     const first = scanner.scan();
     expect(first.components.length).toBeGreaterThan(0);
@@ -112,7 +123,7 @@ describe('createScanner', () => {
   });
 
   it('should produce the same manifest on repeated scans when files are unchanged', () => {
-    const scanner = createScanner({ entryPoint });
+    const scanner = createScanner({ entryPoints });
 
     const first = scanner.scan();
     const second = scanner.scan();
@@ -123,12 +134,66 @@ describe('createScanner', () => {
     );
   });
 
+  it('should dedupe a component re-exported by multiple entry points', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const scanner = createScanner({
+        entryPoints: [
+          {
+            entryFile: path.join(FIXTURES_DIR, 'entry-a.ts'),
+            importPath: 'lib/a',
+          },
+          {
+            entryFile: path.join(FIXTURES_DIR, 'entry-b.ts'),
+            importPath: 'lib/b',
+          },
+        ],
+      });
+      const result = scanner.scan();
+
+      const buttons = result.components.filter(
+        (c) => c.className === 'ButtonComponent'
+      );
+      expect(buttons).toHaveLength(1);
+      // First-occurrence wins → importPath should be 'lib/a'
+      expect(buttons[0].importPath).toBe('lib/a');
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('exported by multiple entry points')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('should isolate a failing entry: other entries still scanned', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const scanner = createScanner({
+        entryPoints: [
+          { entryFile: '/non-existent/file.ts', importPath: 'broken' },
+          { entryFile, importPath: 'good' },
+        ],
+      });
+      const result = scanner.scan();
+
+      // 6 components from the valid entry; the broken entry contributes nothing
+      expect(result.components).toHaveLength(6);
+      for (const c of result.components) {
+        expect(c.importPath).toBe('good');
+      }
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   it('should pick up file changes between scans', () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'ng-prism-scanner-'));
     try {
       cpSync(FIXTURES_DIR, tmpDir, { recursive: true });
       const mutableEntry = join(tmpDir, 'public-api.ts');
-      const scanner = createScanner({ entryPoint: mutableEntry });
+      const scanner = createScanner({
+        entryPoints: [{ entryFile: mutableEntry, importPath: 'fixture' }],
+      });
 
       const first = scanner.scan();
       const originalButton = first.components.find(

--- a/packages/ng-prism/src/builder/scanner/scanner.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/scanner.spec.ts
@@ -135,7 +135,9 @@ describe('createScanner', () => {
   });
 
   it('should dedupe a component re-exported by multiple entry points', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     try {
       const scanner = createScanner({
         entryPoints: [
@@ -166,7 +168,9 @@ describe('createScanner', () => {
   });
 
   it('should isolate a failing entry: other entries still scanned', () => {
-    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const warn = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
     try {
       const scanner = createScanner({
         entryPoints: [

--- a/packages/ng-prism/src/builder/scanner/scanner.ts
+++ b/packages/ng-prism/src/builder/scanner/scanner.ts
@@ -1,16 +1,23 @@
 import ts from 'typescript';
-import type { PrismManifest } from '../../plugin/plugin.types.js';
-import { resolveEntryPointExports } from './entry-point.scanner.js';
+import type { ScannedComponent } from '../../plugin/plugin.types.js';
+import {
+  resolveEntryPointExports,
+  type EntryPointInput,
+} from './entry-point.scanner.js';
 import { scanComponents } from './component.scanner.js';
 
 export interface CreateScannerOptions {
-  entryPoint: string;
+  entryPoints: ReadonlyArray<EntryPointInput>;
   compilerOptions?: ts.CompilerOptions;
 }
 
+export interface ScanResult {
+  components: ScannedComponent[];
+}
+
 export interface Scanner {
-  /** Scan the entry point. Reuses TypeScript program state from previous scans. */
-  scan(): PrismManifest;
+  /** Scan all entry points. Reuses TypeScript program state from previous scans. */
+  scan(): ScanResult;
 }
 
 const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -20,29 +27,69 @@ const DEFAULT_COMPILER_OPTIONS: ts.CompilerOptions = {
   experimentalDecorators: true,
   strict: true,
   skipLibCheck: true,
+  // Perf: skip auto-loading every @types/* package; library source rarely needs ambient globals.
+  // Users with explicit needs can pass `types: ['node']` via tsconfig.json paths.
+  types: [],
+  // Perf: we never call program.emit(); skip emit-related setup work.
+  noEmit: true,
+  // Perf: complement to skipLibCheck — also skip type-checking lib.*.d.ts files.
+  skipDefaultLibCheck: true,
 };
 
 /**
- * Create a stateful scanner that retains the previous ts.Program between scans.
- * TypeScript reuses parsed SourceFile objects from the old program, making incremental scans fast.
+ * Create a stateful multi-entry scanner that retains the previous ts.Program between scans.
+ * A single shared program is created with every entry-point file as a root name, so the
+ * transitive type graph (Angular framework typings, etc.) is parsed once and shared via
+ * the program's `TypeChecker` — instead of N programs that each load Material/CDK/RxJS.
+ *
+ * TypeScript reuses parsed SourceFile objects from the old program on rebuild, making
+ * incremental scans fast.
  */
 export function createScanner(options: CreateScannerOptions): Scanner {
-  const compilerOptions = { ...DEFAULT_COMPILER_OPTIONS, ...options.compilerOptions };
+  const compilerOptions = {
+    ...DEFAULT_COMPILER_OPTIONS,
+    ...options.compilerOptions,
+  };
   let previousProgram: ts.Program | undefined;
 
   return {
-    scan(): PrismManifest {
-      const { program, exports } = resolveEntryPointExports(
-        options.entryPoint,
+    scan(): ScanResult {
+      const { program, entries } = resolveEntryPointExports(
+        options.entryPoints,
         compilerOptions,
-        previousProgram,
+        previousProgram
       );
       previousProgram = program;
 
       const checker = program.getTypeChecker();
-      const components = scanComponents(exports, checker);
+      const allComponents: ScannedComponent[] = [];
 
-      return { components };
+      for (const { exports, importPath } of entries) {
+        const components = scanComponents(exports, checker);
+        for (const c of components) c.importPath = importPath;
+        allComponents.push(...components);
+      }
+
+      // Dedupe by (filePath, className): if a component class is re-exported from
+      // multiple entry points (e.g. atoms/button + barrel index.ts), we keep the first
+      // occurrence. The duplicate would otherwise produce duplicate imports in the
+      // generated manifest and a runtime collision in the Prism shell.
+      const seen = new Set<string>();
+      const unique: ScannedComponent[] = [];
+      for (const c of allComponents) {
+        const key = `${c.filePath}::${c.className}`;
+        if (seen.has(key)) {
+          console.warn(
+            `⚠ ng-prism: ${c.className} is exported by multiple entry points; ` +
+              `keeping the first occurrence (importPath: ${unique.find((u) => u.className === c.className && u.filePath === c.filePath)?.importPath}).`
+          );
+          continue;
+        }
+        seen.add(key);
+        unique.push(c);
+      }
+
+      return { components: unique };
     },
   };
 }

--- a/packages/ng-prism/src/builder/scanner/scanner.ts
+++ b/packages/ng-prism/src/builder/scanner/scanner.ts
@@ -81,7 +81,12 @@ export function createScanner(options: CreateScannerOptions): Scanner {
         if (seen.has(key)) {
           console.warn(
             `⚠ ng-prism: ${c.className} is exported by multiple entry points; ` +
-              `keeping the first occurrence (importPath: ${unique.find((u) => u.className === c.className && u.filePath === c.filePath)?.importPath}).`
+              `keeping the first occurrence (importPath: ${
+                unique.find(
+                  (u) =>
+                    u.className === c.className && u.filePath === c.filePath
+                )?.importPath
+              }).`
           );
           continue;
         }

--- a/packages/ng-prism/src/builder/shared/prism-pipeline.spec.ts
+++ b/packages/ng-prism/src/builder/shared/prism-pipeline.spec.ts
@@ -240,12 +240,13 @@ describe('createPipelineState', () => {
     const b = createPipelineState();
 
     expect(a).not.toBe(b);
-    expect(a.scanners).not.toBe(b.scanners);
-    expect(a.scanners.size).toBe(0);
-    expect(b.scanners.size).toBe(0);
+    expect(a.scanner).toBeUndefined();
+    expect(b.scanner).toBeUndefined();
+    expect(a.lastEntrySetKey).toBeUndefined();
+    expect(b.lastEntrySetKey).toBeUndefined();
   });
 
-  it('should populate scanners map after pipeline run', async () => {
+  it('should populate scanner state after pipeline run', async () => {
     const tmp = createTempWorkspace();
     const ctx = createMockContext(tmp, 'prism-app/src');
     const state = createPipelineState();
@@ -262,7 +263,8 @@ describe('createPipelineState', () => {
         state
       );
 
-      expect(state.scanners.size).toBeGreaterThan(0);
+      expect(state.scanner).toBeDefined();
+      expect(state.lastEntrySetKey).toBeDefined();
     } finally {
       rmSync(tmp, { recursive: true, force: true });
     }
@@ -282,15 +284,12 @@ describe('createPipelineState', () => {
       };
 
       await runPrismPipeline(options, ctx, state);
-      const firstScanner = state.scanners.get(
-        join(tmp, 'lib', 'public-api.ts')
-      );
+      const firstScanner = state.scanner;
 
       await runPrismPipeline(options, ctx, state);
-      const secondScanner = state.scanners.get(
-        join(tmp, 'lib', 'public-api.ts')
-      );
+      const secondScanner = state.scanner;
 
+      expect(firstScanner).toBeDefined();
       expect(secondScanner).toBe(firstScanner);
     } finally {
       rmSync(tmp, { recursive: true, force: true });

--- a/packages/ng-prism/src/builder/shared/prism-pipeline.ts
+++ b/packages/ng-prism/src/builder/shared/prism-pipeline.ts
@@ -11,11 +11,9 @@ import {
 import ts from 'typescript';
 import type { BuilderContext } from '@angular-devkit/architect';
 import type { StyleguidePage } from '../../plugin/page.types.js';
-import type {
-  ScannedComponent,
-  PrismManifest,
-} from '../../plugin/plugin.types.js';
+import type { PrismManifest } from '../../plugin/plugin.types.js';
 import { createScanner, type Scanner } from '../scanner/scanner.js';
+import type { EntryPointInput } from '../scanner/entry-point.scanner.js';
 import { discoverSecondaryEntryPoints } from '../scanner/entry-point-discovery.js';
 import { loadConfig } from '../config-loader/config-loader.js';
 import { runPluginHooks } from '../plugin-runner/plugin-runner.js';
@@ -37,11 +35,13 @@ export interface PrismPipelineResult {
 }
 
 export interface PrismPipelineState {
-  scanners: Map<string, Scanner>;
+  scanner: Scanner | undefined;
+  /** Sorted, joined entry-file paths — used to detect when the entry set changed between rebuilds. */
+  lastEntrySetKey: string | undefined;
 }
 
 export function createPipelineState(): PrismPipelineState {
-  return { scanners: new Map() };
+  return { scanner: undefined, lastEntrySetKey: undefined };
 }
 
 export async function runPrismPipeline(
@@ -173,55 +173,61 @@ function resolveTsconfigPaths(entryPointDir: string): ts.CompilerOptions {
   return result;
 }
 
-function scanEntryPoints(
+function resolveEntryPoints(
   workspaceRoot: string,
-  options: PrismPipelineOptions,
-  state: PrismPipelineState
-): PrismManifest {
+  options: PrismPipelineOptions
+): { entryPoints: EntryPointInput[]; compilerOptions: ts.CompilerOptions } {
   const absoluteEntryPoint = join(workspaceRoot, options.entryPoint);
-  const pathOptions = resolveTsconfigPaths(dirname(absoluteEntryPoint));
+  const compilerOptions = resolveTsconfigPaths(dirname(absoluteEntryPoint));
 
   const entryIsDirectory = isDirectory(absoluteEntryPoint);
   const libraryRoot = entryIsDirectory
     ? absoluteEntryPoint
     : findLibraryRoot(absoluteEntryPoint);
 
-  if (!libraryRoot) {
-    return getOrCreateScanner(state, absoluteEntryPoint, pathOptions).scan();
-  }
+  const discovered = libraryRoot
+    ? discoverSecondaryEntryPoints(libraryRoot, options.libraryImportPath)
+    : [];
 
-  const entryPoints = discoverSecondaryEntryPoints(
-    libraryRoot,
-    options.libraryImportPath
-  );
+  // Fallback to a direct file scan when:
+  //  - the entry is a file and no ng-package.json was found above it, OR
+  //  - the entry is a file with an ng-package.json above it but discovery found nothing
+  //    (e.g. primary-only library, root ng-package.json carries `dest`).
+  const entryPoints: EntryPointInput[] =
+    discovered.length === 0 && !entryIsDirectory
+      ? [
+          {
+            entryFile: absoluteEntryPoint,
+            importPath: options.libraryImportPath,
+          },
+        ]
+      : discovered;
 
-  if (entryPoints.length === 0 && !entryIsDirectory) {
-    return getOrCreateScanner(state, absoluteEntryPoint, pathOptions).scan();
-  }
-
-  const allComponents: ScannedComponent[] = [];
-
-  for (const ep of entryPoints) {
-    const scanner = getOrCreateScanner(state, ep.entryFile, pathOptions);
-    const result = scanner.scan();
-    for (const comp of result.components) {
-      comp.importPath = ep.importPath;
-      allComponents.push(comp);
-    }
-  }
-
-  return { components: allComponents };
+  return { entryPoints, compilerOptions };
 }
 
-function getOrCreateScanner(
-  state: PrismPipelineState,
-  entryFile: string,
-  compilerOptions: ts.CompilerOptions
-): Scanner {
-  let scanner = state.scanners.get(entryFile);
-  if (!scanner) {
-    scanner = createScanner({ entryPoint: entryFile, compilerOptions });
-    state.scanners.set(entryFile, scanner);
+function scanEntryPoints(
+  workspaceRoot: string,
+  options: PrismPipelineOptions,
+  state: PrismPipelineState
+): PrismManifest {
+  const { entryPoints, compilerOptions } = resolveEntryPoints(
+    workspaceRoot,
+    options
+  );
+
+  const newKey = entryPoints
+    .map((e) => e.entryFile)
+    .slice()
+    .sort()
+    .join('|');
+
+  if (newKey !== state.lastEntrySetKey) {
+    state.scanner = undefined;
+    state.lastEntrySetKey = newKey;
   }
-  return scanner;
+
+  state.scanner ??= createScanner({ entryPoints, compilerOptions });
+
+  return state.scanner.scan();
 }

--- a/test-workspace/measure-pipeline.mjs
+++ b/test-workspace/measure-pipeline.mjs
@@ -1,0 +1,38 @@
+// Cold-scan memory + time bench for the shared-ts-program refactor (#8 / #9).
+// Run with: node measure-pipeline.mjs   (from test-workspace/)
+//
+// Invokes the pipeline directly against the expanded test-ui-kit fixture
+// (15 secondaries × Material/CDK imports) and reports heap delta + duration.
+// Requires `npx nx build ng-prism` first so the dist/ output exists.
+
+import { runPrismPipeline, createPipelineState } from '../packages/ng-prism/dist/builder/shared/prism-pipeline.js';
+
+const workspaceRoot = process.cwd();
+const ctx = {
+  workspaceRoot,
+  reportStatus: () => {},
+  logger: { info: (m) => console.log(m), error: (m) => console.error(m) },
+  getProjectMetadata: async () => ({ sourceRoot: 'projects/test-ui-kit-prism/src' }),
+};
+
+const before = process.memoryUsage();
+console.log(`heap before: ${(before.heapUsed / 1024 / 1024).toFixed(1)} MB | rss before: ${(before.rss / 1024 / 1024).toFixed(1)} MB`);
+
+const t0 = Date.now();
+const result = await runPrismPipeline(
+  {
+    entryPoint: 'projects/test-ui-kit',
+    libraryImportPath: 'test-ui-kit',
+    prismProject: 'test-ui-kit-prism',
+    configFile: 'ng-prism.config.ts',
+  },
+  ctx,
+  createPipelineState(),
+);
+const dt = Date.now() - t0;
+
+const after = process.memoryUsage();
+console.log(`heap after:  ${(after.heapUsed / 1024 / 1024).toFixed(1)} MB | rss after:  ${(after.rss / 1024 / 1024).toFixed(1)} MB`);
+console.log(`delta heap:  ${((after.heapUsed - before.heapUsed) / 1024 / 1024).toFixed(1)} MB`);
+console.log(`time: ${dt} ms`);
+console.log(`components: ${result.componentCount}, pages: ${result.pageCount}`);

--- a/test-workspace/measure-pipeline.mjs
+++ b/test-workspace/measure-pipeline.mjs
@@ -5,18 +5,27 @@
 // (15 secondaries × Material/CDK imports) and reports heap delta + duration.
 // Requires `npx nx build ng-prism` first so the dist/ output exists.
 
-import { runPrismPipeline, createPipelineState } from '../packages/ng-prism/dist/builder/shared/prism-pipeline.js';
+import {
+  runPrismPipeline,
+  createPipelineState,
+} from '../packages/ng-prism/dist/builder/shared/prism-pipeline.js';
 
 const workspaceRoot = process.cwd();
 const ctx = {
   workspaceRoot,
   reportStatus: () => {},
   logger: { info: (m) => console.log(m), error: (m) => console.error(m) },
-  getProjectMetadata: async () => ({ sourceRoot: 'projects/test-ui-kit-prism/src' }),
+  getProjectMetadata: async () => ({
+    sourceRoot: 'projects/test-ui-kit-prism/src',
+  }),
 };
 
 const before = process.memoryUsage();
-console.log(`heap before: ${(before.heapUsed / 1024 / 1024).toFixed(1)} MB | rss before: ${(before.rss / 1024 / 1024).toFixed(1)} MB`);
+console.log(
+  `heap before: ${(before.heapUsed / 1024 / 1024).toFixed(
+    1
+  )} MB | rss before: ${(before.rss / 1024 / 1024).toFixed(1)} MB`
+);
 
 const t0 = Date.now();
 const result = await runPrismPipeline(
@@ -27,12 +36,20 @@ const result = await runPrismPipeline(
     configFile: 'ng-prism.config.ts',
   },
   ctx,
-  createPipelineState(),
+  createPipelineState()
 );
 const dt = Date.now() - t0;
 
 const after = process.memoryUsage();
-console.log(`heap after:  ${(after.heapUsed / 1024 / 1024).toFixed(1)} MB | rss after:  ${(after.rss / 1024 / 1024).toFixed(1)} MB`);
-console.log(`delta heap:  ${((after.heapUsed - before.heapUsed) / 1024 / 1024).toFixed(1)} MB`);
+console.log(
+  `heap after:  ${(after.heapUsed / 1024 / 1024).toFixed(
+    1
+  )} MB | rss after:  ${(after.rss / 1024 / 1024).toFixed(1)} MB`
+);
+console.log(
+  `delta heap:  ${((after.heapUsed - before.heapUsed) / 1024 / 1024).toFixed(
+    1
+  )} MB`
+);
 console.log(`time: ${dt} ms`);
 console.log(`components: ${result.componentCount}, pages: ${result.pageCount}`);

--- a/test-workspace/measure-watch-rebuilds.mjs
+++ b/test-workspace/measure-watch-rebuilds.mjs
@@ -1,0 +1,99 @@
+// Watch-mode steady-state bench for the shared-ts-program refactor.
+// Run with: node --expose-gc measure-watch-rebuilds.mjs
+//
+// Loops N rebuilds against test-ui-kit, mutating one component file between each call.
+// Reports per-rebuild RSS + duration, then validates that after warm-up the RSS does
+// not drift more than 10% — the steady-state criterion from the design doc.
+
+import {
+  runPrismPipeline,
+  createPipelineState,
+} from '../packages/ng-prism/dist/builder/shared/prism-pipeline.js';
+import { readFileSync, writeFileSync } from 'fs';
+
+const ITERATIONS = 100;
+const WARMUP = 5;
+const STEADY_STATE_TOLERANCE = 0.10; // 10%
+
+const workspaceRoot = process.cwd();
+const ctx = {
+  workspaceRoot,
+  reportStatus: () => {},
+  logger: { info: () => {}, error: (m) => console.error(m) },
+  getProjectMetadata: async () => ({
+    sourceRoot: 'projects/test-ui-kit-prism/src',
+  }),
+};
+const options = {
+  entryPoint: 'projects/test-ui-kit',
+  libraryImportPath: 'test-ui-kit',
+  prismProject: 'test-ui-kit-prism',
+  configFile: 'ng-prism.config.ts',
+};
+const state = createPipelineState();
+
+const targetFile = 'projects/test-ui-kit/button/button.component.ts';
+const original = readFileSync(targetFile, 'utf-8');
+
+const samples = [];
+
+try {
+  for (let i = 0; i < ITERATIONS; i++) {
+    // Mutate the file (append a unique trailing comment) so TS invalidates its SourceFile.
+    writeFileSync(targetFile, `${original}\n// rebuild marker ${i}\n`);
+
+    const t0 = Date.now();
+    await runPrismPipeline(options, ctx, state);
+    const dt = Date.now() - t0;
+
+    if (global.gc) global.gc();
+    const rss = process.memoryUsage().rss;
+    const heap = process.memoryUsage().heapUsed;
+    samples.push({ i, rss, heap, dt });
+
+    const rssMb = (rss / 1024 / 1024).toFixed(1);
+    const heapMb = (heap / 1024 / 1024).toFixed(1);
+    console.log(
+      `rebuild ${String(i).padStart(3)}: RSS=${rssMb} MB | heap=${heapMb} MB | scan=${dt} ms`
+    );
+  }
+} finally {
+  writeFileSync(targetFile, original);
+}
+
+const warm = samples.slice(WARMUP);
+const rssMin = Math.min(...warm.map((s) => s.rss));
+const rssMax = Math.max(...warm.map((s) => s.rss));
+const rssVar = (rssMax - rssMin) / rssMin;
+
+const heapMin = Math.min(...warm.map((s) => s.heap));
+const heapMax = Math.max(...warm.map((s) => s.heap));
+const heapVar = (heapMax - heapMin) / heapMin;
+
+const dtMean =
+  warm.reduce((sum, s) => sum + s.dt, 0) / warm.length;
+const dtP95 = warm
+  .map((s) => s.dt)
+  .sort((a, b) => a - b)[Math.floor(warm.length * 0.95)];
+
+console.log(`\n=== Steady-state summary (rebuilds ${WARMUP}–${ITERATIONS - 1}) ===`);
+console.log(
+  `RSS:  min ${(rssMin / 1024 / 1024).toFixed(1)} MB,  max ${(
+    rssMax / 1024 / 1024
+  ).toFixed(1)} MB,  variation ${(rssVar * 100).toFixed(1)}%`
+);
+console.log(
+  `Heap: min ${(heapMin / 1024 / 1024).toFixed(1)} MB,  max ${(
+    heapMax / 1024 / 1024
+  ).toFixed(1)} MB,  variation ${(heapVar * 100).toFixed(1)}%`
+);
+console.log(`Scan: mean ${dtMean.toFixed(0)} ms,  p95 ${dtP95} ms`);
+console.log(`Cold scan (rebuild 0): ${samples[0].dt} ms`);
+
+const pass = rssVar <= STEADY_STATE_TOLERANCE;
+console.log(
+  `\nSteady-state criterion (RSS variation ≤ ${(STEADY_STATE_TOLERANCE * 100).toFixed(0)}%): ${
+    pass ? 'PASS ✓' : 'FAIL ✗'
+  }`
+);
+process.exit(pass ? 0 : 1);

--- a/test-workspace/measure-watch-rebuilds.mjs
+++ b/test-workspace/measure-watch-rebuilds.mjs
@@ -13,7 +13,7 @@ import { readFileSync, writeFileSync } from 'fs';
 
 const ITERATIONS = 100;
 const WARMUP = 5;
-const STEADY_STATE_TOLERANCE = 0.10; // 10%
+const STEADY_STATE_TOLERANCE = 0.1; // 10%
 
 const workspaceRoot = process.cwd();
 const ctx = {
@@ -54,7 +54,9 @@ try {
     const rssMb = (rss / 1024 / 1024).toFixed(1);
     const heapMb = (heap / 1024 / 1024).toFixed(1);
     console.log(
-      `rebuild ${String(i).padStart(3)}: RSS=${rssMb} MB | heap=${heapMb} MB | scan=${dt} ms`
+      `rebuild ${String(i).padStart(
+        3
+      )}: RSS=${rssMb} MB | heap=${heapMb} MB | scan=${dt} ms`
     );
   }
 } finally {
@@ -70,21 +72,26 @@ const heapMin = Math.min(...warm.map((s) => s.heap));
 const heapMax = Math.max(...warm.map((s) => s.heap));
 const heapVar = (heapMax - heapMin) / heapMin;
 
-const dtMean =
-  warm.reduce((sum, s) => sum + s.dt, 0) / warm.length;
-const dtP95 = warm
-  .map((s) => s.dt)
-  .sort((a, b) => a - b)[Math.floor(warm.length * 0.95)];
+const dtMean = warm.reduce((sum, s) => sum + s.dt, 0) / warm.length;
+const dtP95 = warm.map((s) => s.dt).sort((a, b) => a - b)[
+  Math.floor(warm.length * 0.95)
+];
 
-console.log(`\n=== Steady-state summary (rebuilds ${WARMUP}–${ITERATIONS - 1}) ===`);
+console.log(
+  `\n=== Steady-state summary (rebuilds ${WARMUP}–${ITERATIONS - 1}) ===`
+);
 console.log(
   `RSS:  min ${(rssMin / 1024 / 1024).toFixed(1)} MB,  max ${(
-    rssMax / 1024 / 1024
+    rssMax /
+    1024 /
+    1024
   ).toFixed(1)} MB,  variation ${(rssVar * 100).toFixed(1)}%`
 );
 console.log(
   `Heap: min ${(heapMin / 1024 / 1024).toFixed(1)} MB,  max ${(
-    heapMax / 1024 / 1024
+    heapMax /
+    1024 /
+    1024
   ).toFixed(1)} MB,  variation ${(heapVar * 100).toFixed(1)}%`
 );
 console.log(`Scan: mean ${dtMean.toFixed(0)} ms,  p95 ${dtP95} ms`);
@@ -92,8 +99,8 @@ console.log(`Cold scan (rebuild 0): ${samples[0].dt} ms`);
 
 const pass = rssVar <= STEADY_STATE_TOLERANCE;
 console.log(
-  `\nSteady-state criterion (RSS variation ≤ ${(STEADY_STATE_TOLERANCE * 100).toFixed(0)}%): ${
-    pass ? 'PASS ✓' : 'FAIL ✗'
-  }`
+  `\nSteady-state criterion (RSS variation ≤ ${(
+    STEADY_STATE_TOLERANCE * 100
+  ).toFixed(0)}%): ${pass ? 'PASS ✓' : 'FAIL ✗'}`
 );
 process.exit(pass ? 0 : 1);

--- a/test-workspace/projects/test-ui-kit/accordion/accordion.component.ts
+++ b/test-workspace/projects/test-ui-kit/accordion/accordion.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatExpansionModule } from "@angular/material/expansion";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Accordion",
+  category: "Components",
+  description: "AccordionComponent from test-ui-kit/accordion secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Accordion" } },
+  ],
+})
+@Component({
+  selector: "uk-accordion",
+  standalone: true,
+  imports: [CommonModule, MatExpansionModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class AccordionComponent {
+  readonly label = input<string>("Accordion");
+}

--- a/test-workspace/projects/test-ui-kit/accordion/accordion.component.ts
+++ b/test-workspace/projects/test-ui-kit/accordion/accordion.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatExpansionModule } from "@angular/material/expansion";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Accordion",
-  category: "Components",
-  description: "AccordionComponent from test-ui-kit/accordion secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Accordion" } },
-  ],
+  title: 'Accordion',
+  category: 'Components',
+  description:
+    'AccordionComponent from test-ui-kit/accordion secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Accordion' } }],
 })
 @Component({
-  selector: "uk-accordion",
+  selector: 'uk-accordion',
   standalone: true,
   imports: [CommonModule, MatExpansionModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class AccordionComponent {
-  readonly label = input<string>("Accordion");
+  readonly label = input<string>('Accordion');
 }

--- a/test-workspace/projects/test-ui-kit/accordion/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/accordion/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/accordion/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/accordion/public-api.ts
@@ -1,0 +1,1 @@
+export { AccordionComponent } from "./accordion.component.js";

--- a/test-workspace/projects/test-ui-kit/accordion/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/accordion/public-api.ts
@@ -1,1 +1,1 @@
-export { AccordionComponent } from "./accordion.component.js";
+export { AccordionComponent } from './accordion.component.js';

--- a/test-workspace/projects/test-ui-kit/alert/alert.component.ts
+++ b/test-workspace/projects/test-ui-kit/alert/alert.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatSnackBarModule } from "@angular/material/snack-bar";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Alert",
-  category: "Components",
-  description: "AlertComponent from test-ui-kit/alert secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Alert" } },
-  ],
+  title: 'Alert',
+  category: 'Components',
+  description: 'AlertComponent from test-ui-kit/alert secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Alert' } }],
 })
 @Component({
-  selector: "uk-alert",
+  selector: 'uk-alert',
   standalone: true,
   imports: [CommonModule, MatSnackBarModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class AlertComponent {
-  readonly label = input<string>("Alert");
+  readonly label = input<string>('Alert');
 }

--- a/test-workspace/projects/test-ui-kit/alert/alert.component.ts
+++ b/test-workspace/projects/test-ui-kit/alert/alert.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatSnackBarModule } from "@angular/material/snack-bar";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Alert",
+  category: "Components",
+  description: "AlertComponent from test-ui-kit/alert secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Alert" } },
+  ],
+})
+@Component({
+  selector: "uk-alert",
+  standalone: true,
+  imports: [CommonModule, MatSnackBarModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class AlertComponent {
+  readonly label = input<string>("Alert");
+}

--- a/test-workspace/projects/test-ui-kit/alert/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/alert/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/alert/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/alert/public-api.ts
@@ -1,1 +1,1 @@
-export { AlertComponent } from "./alert.component.js";
+export { AlertComponent } from './alert.component.js';

--- a/test-workspace/projects/test-ui-kit/alert/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/alert/public-api.ts
@@ -1,0 +1,1 @@
+export { AlertComponent } from "./alert.component.js";

--- a/test-workspace/projects/test-ui-kit/badge/badge.component.ts
+++ b/test-workspace/projects/test-ui-kit/badge/badge.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatBadgeModule } from "@angular/material/badge";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatBadgeModule } from '@angular/material/badge';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Badge",
-  category: "Components",
-  description: "BadgeComponent from test-ui-kit/badge secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Badge" } },
-  ],
+  title: 'Badge',
+  category: 'Components',
+  description: 'BadgeComponent from test-ui-kit/badge secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Badge' } }],
 })
 @Component({
-  selector: "uk-badge",
+  selector: 'uk-badge',
   standalone: true,
   imports: [CommonModule, MatBadgeModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class BadgeComponent {
-  readonly label = input<string>("Badge");
+  readonly label = input<string>('Badge');
 }

--- a/test-workspace/projects/test-ui-kit/badge/badge.component.ts
+++ b/test-workspace/projects/test-ui-kit/badge/badge.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatBadgeModule } from "@angular/material/badge";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Badge",
+  category: "Components",
+  description: "BadgeComponent from test-ui-kit/badge secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Badge" } },
+  ],
+})
+@Component({
+  selector: "uk-badge",
+  standalone: true,
+  imports: [CommonModule, MatBadgeModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class BadgeComponent {
+  readonly label = input<string>("Badge");
+}

--- a/test-workspace/projects/test-ui-kit/badge/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/badge/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/badge/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/badge/public-api.ts
@@ -1,0 +1,1 @@
+export { BadgeComponent } from "./badge.component.js";

--- a/test-workspace/projects/test-ui-kit/badge/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/badge/public-api.ts
@@ -1,1 +1,1 @@
-export { BadgeComponent } from "./badge.component.js";
+export { BadgeComponent } from './badge.component.js';

--- a/test-workspace/projects/test-ui-kit/checkbox/checkbox.component.ts
+++ b/test-workspace/projects/test-ui-kit/checkbox/checkbox.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatCheckboxModule } from "@angular/material/checkbox";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Checkbox",
-  category: "Components",
-  description: "CheckboxComponent from test-ui-kit/checkbox secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Checkbox" } },
-  ],
+  title: 'Checkbox',
+  category: 'Components',
+  description:
+    'CheckboxComponent from test-ui-kit/checkbox secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Checkbox' } }],
 })
 @Component({
-  selector: "uk-checkbox",
+  selector: 'uk-checkbox',
   standalone: true,
   imports: [CommonModule, MatCheckboxModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class CheckboxComponent {
-  readonly label = input<string>("Checkbox");
+  readonly label = input<string>('Checkbox');
 }

--- a/test-workspace/projects/test-ui-kit/checkbox/checkbox.component.ts
+++ b/test-workspace/projects/test-ui-kit/checkbox/checkbox.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatCheckboxModule } from "@angular/material/checkbox";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Checkbox",
+  category: "Components",
+  description: "CheckboxComponent from test-ui-kit/checkbox secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Checkbox" } },
+  ],
+})
+@Component({
+  selector: "uk-checkbox",
+  standalone: true,
+  imports: [CommonModule, MatCheckboxModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class CheckboxComponent {
+  readonly label = input<string>("Checkbox");
+}

--- a/test-workspace/projects/test-ui-kit/checkbox/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/checkbox/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/checkbox/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/checkbox/public-api.ts
@@ -1,0 +1,1 @@
+export { CheckboxComponent } from "./checkbox.component.js";

--- a/test-workspace/projects/test-ui-kit/checkbox/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/checkbox/public-api.ts
@@ -1,1 +1,1 @@
-export { CheckboxComponent } from "./checkbox.component.js";
+export { CheckboxComponent } from './checkbox.component.js';

--- a/test-workspace/projects/test-ui-kit/chip/chip.component.ts
+++ b/test-workspace/projects/test-ui-kit/chip/chip.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatChipsModule } from "@angular/material/chips";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatChipsModule } from '@angular/material/chips';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Chip",
-  category: "Components",
-  description: "ChipComponent from test-ui-kit/chip secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Chip" } },
-  ],
+  title: 'Chip',
+  category: 'Components',
+  description: 'ChipComponent from test-ui-kit/chip secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Chip' } }],
 })
 @Component({
-  selector: "uk-chip",
+  selector: 'uk-chip',
   standalone: true,
   imports: [CommonModule, MatChipsModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class ChipComponent {
-  readonly label = input<string>("Chip");
+  readonly label = input<string>('Chip');
 }

--- a/test-workspace/projects/test-ui-kit/chip/chip.component.ts
+++ b/test-workspace/projects/test-ui-kit/chip/chip.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatChipsModule } from "@angular/material/chips";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Chip",
+  category: "Components",
+  description: "ChipComponent from test-ui-kit/chip secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Chip" } },
+  ],
+})
+@Component({
+  selector: "uk-chip",
+  standalone: true,
+  imports: [CommonModule, MatChipsModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class ChipComponent {
+  readonly label = input<string>("Chip");
+}

--- a/test-workspace/projects/test-ui-kit/chip/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/chip/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/chip/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/chip/public-api.ts
@@ -1,1 +1,1 @@
-export { ChipComponent } from "./chip.component.js";
+export { ChipComponent } from './chip.component.js';

--- a/test-workspace/projects/test-ui-kit/chip/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/chip/public-api.ts
@@ -1,0 +1,1 @@
+export { ChipComponent } from "./chip.component.js";

--- a/test-workspace/projects/test-ui-kit/dialog/dialog.component.ts
+++ b/test-workspace/projects/test-ui-kit/dialog/dialog.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatDialogModule } from "@angular/material/dialog";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Dialog",
+  category: "Components",
+  description: "DialogComponent from test-ui-kit/dialog secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Dialog" } },
+  ],
+})
+@Component({
+  selector: "uk-dialog",
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class DialogComponent {
+  readonly label = input<string>("Dialog");
+}

--- a/test-workspace/projects/test-ui-kit/dialog/dialog.component.ts
+++ b/test-workspace/projects/test-ui-kit/dialog/dialog.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatDialogModule } from "@angular/material/dialog";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Dialog",
-  category: "Components",
-  description: "DialogComponent from test-ui-kit/dialog secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Dialog" } },
-  ],
+  title: 'Dialog',
+  category: 'Components',
+  description: 'DialogComponent from test-ui-kit/dialog secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Dialog' } }],
 })
 @Component({
-  selector: "uk-dialog",
+  selector: 'uk-dialog',
   standalone: true,
   imports: [CommonModule, MatDialogModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class DialogComponent {
-  readonly label = input<string>("Dialog");
+  readonly label = input<string>('Dialog');
 }

--- a/test-workspace/projects/test-ui-kit/dialog/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/dialog/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/dialog/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/dialog/public-api.ts
@@ -1,1 +1,1 @@
-export { DialogComponent } from "./dialog.component.js";
+export { DialogComponent } from './dialog.component.js';

--- a/test-workspace/projects/test-ui-kit/dialog/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/dialog/public-api.ts
@@ -1,0 +1,1 @@
+export { DialogComponent } from "./dialog.component.js";

--- a/test-workspace/projects/test-ui-kit/form-field/form-field.component.ts
+++ b/test-workspace/projects/test-ui-kit/form-field/form-field.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatFormFieldModule } from "@angular/material/form-field";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "FormField",
-  category: "Components",
-  description: "FormFieldComponent from test-ui-kit/form-field secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "FormField" } },
-  ],
+  title: 'FormField',
+  category: 'Components',
+  description:
+    'FormFieldComponent from test-ui-kit/form-field secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'FormField' } }],
 })
 @Component({
-  selector: "uk-form-field",
+  selector: 'uk-form-field',
   standalone: true,
   imports: [CommonModule, MatFormFieldModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class FormFieldComponent {
-  readonly label = input<string>("FormField");
+  readonly label = input<string>('FormField');
 }

--- a/test-workspace/projects/test-ui-kit/form-field/form-field.component.ts
+++ b/test-workspace/projects/test-ui-kit/form-field/form-field.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatFormFieldModule } from "@angular/material/form-field";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "FormField",
+  category: "Components",
+  description: "FormFieldComponent from test-ui-kit/form-field secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "FormField" } },
+  ],
+})
+@Component({
+  selector: "uk-form-field",
+  standalone: true,
+  imports: [CommonModule, MatFormFieldModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class FormFieldComponent {
+  readonly label = input<string>("FormField");
+}

--- a/test-workspace/projects/test-ui-kit/form-field/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/form-field/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/form-field/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/form-field/public-api.ts
@@ -1,1 +1,1 @@
-export { FormFieldComponent } from "./form-field.component.js";
+export { FormFieldComponent } from './form-field.component.js';

--- a/test-workspace/projects/test-ui-kit/form-field/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/form-field/public-api.ts
@@ -1,0 +1,1 @@
+export { FormFieldComponent } from "./form-field.component.js";

--- a/test-workspace/projects/test-ui-kit/progress/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/progress/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/progress/progress.component.ts
+++ b/test-workspace/projects/test-ui-kit/progress/progress.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatProgressBarModule } from "@angular/material/progress-bar";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Progress",
-  category: "Components",
-  description: "ProgressComponent from test-ui-kit/progress secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Progress" } },
-  ],
+  title: 'Progress',
+  category: 'Components',
+  description:
+    'ProgressComponent from test-ui-kit/progress secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Progress' } }],
 })
 @Component({
-  selector: "uk-progress",
+  selector: 'uk-progress',
   standalone: true,
   imports: [CommonModule, MatProgressBarModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class ProgressComponent {
-  readonly label = input<string>("Progress");
+  readonly label = input<string>('Progress');
 }

--- a/test-workspace/projects/test-ui-kit/progress/progress.component.ts
+++ b/test-workspace/projects/test-ui-kit/progress/progress.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatProgressBarModule } from "@angular/material/progress-bar";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Progress",
+  category: "Components",
+  description: "ProgressComponent from test-ui-kit/progress secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Progress" } },
+  ],
+})
+@Component({
+  selector: "uk-progress",
+  standalone: true,
+  imports: [CommonModule, MatProgressBarModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class ProgressComponent {
+  readonly label = input<string>("Progress");
+}

--- a/test-workspace/projects/test-ui-kit/progress/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/progress/public-api.ts
@@ -1,1 +1,1 @@
-export { ProgressComponent } from "./progress.component.js";
+export { ProgressComponent } from './progress.component.js';

--- a/test-workspace/projects/test-ui-kit/progress/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/progress/public-api.ts
@@ -1,0 +1,1 @@
+export { ProgressComponent } from "./progress.component.js";

--- a/test-workspace/projects/test-ui-kit/select/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/select/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/select/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/select/public-api.ts
@@ -1,1 +1,1 @@
-export { SelectComponent } from "./select.component.js";
+export { SelectComponent } from './select.component.js';

--- a/test-workspace/projects/test-ui-kit/select/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/select/public-api.ts
@@ -1,0 +1,1 @@
+export { SelectComponent } from "./select.component.js";

--- a/test-workspace/projects/test-ui-kit/select/select.component.ts
+++ b/test-workspace/projects/test-ui-kit/select/select.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatSelectModule } from "@angular/material/select";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatSelectModule } from '@angular/material/select';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Select",
-  category: "Components",
-  description: "SelectComponent from test-ui-kit/select secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Select" } },
-  ],
+  title: 'Select',
+  category: 'Components',
+  description: 'SelectComponent from test-ui-kit/select secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Select' } }],
 })
 @Component({
-  selector: "uk-select",
+  selector: 'uk-select',
   standalone: true,
   imports: [CommonModule, MatSelectModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class SelectComponent {
-  readonly label = input<string>("Select");
+  readonly label = input<string>('Select');
 }

--- a/test-workspace/projects/test-ui-kit/select/select.component.ts
+++ b/test-workspace/projects/test-ui-kit/select/select.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatSelectModule } from "@angular/material/select";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Select",
+  category: "Components",
+  description: "SelectComponent from test-ui-kit/select secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Select" } },
+  ],
+})
+@Component({
+  selector: "uk-select",
+  standalone: true,
+  imports: [CommonModule, MatSelectModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class SelectComponent {
+  readonly label = input<string>("Select");
+}

--- a/test-workspace/projects/test-ui-kit/slider/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/slider/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/slider/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/slider/public-api.ts
@@ -1,0 +1,1 @@
+export { SliderComponent } from "./slider.component.js";

--- a/test-workspace/projects/test-ui-kit/slider/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/slider/public-api.ts
@@ -1,1 +1,1 @@
-export { SliderComponent } from "./slider.component.js";
+export { SliderComponent } from './slider.component.js';

--- a/test-workspace/projects/test-ui-kit/slider/slider.component.ts
+++ b/test-workspace/projects/test-ui-kit/slider/slider.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatSliderModule } from "@angular/material/slider";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatSliderModule } from '@angular/material/slider';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Slider",
-  category: "Components",
-  description: "SliderComponent from test-ui-kit/slider secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Slider" } },
-  ],
+  title: 'Slider',
+  category: 'Components',
+  description: 'SliderComponent from test-ui-kit/slider secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Slider' } }],
 })
 @Component({
-  selector: "uk-slider",
+  selector: 'uk-slider',
   standalone: true,
   imports: [CommonModule, MatSliderModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class SliderComponent {
-  readonly label = input<string>("Slider");
+  readonly label = input<string>('Slider');
 }

--- a/test-workspace/projects/test-ui-kit/slider/slider.component.ts
+++ b/test-workspace/projects/test-ui-kit/slider/slider.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatSliderModule } from "@angular/material/slider";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Slider",
+  category: "Components",
+  description: "SliderComponent from test-ui-kit/slider secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Slider" } },
+  ],
+})
+@Component({
+  selector: "uk-slider",
+  standalone: true,
+  imports: [CommonModule, MatSliderModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class SliderComponent {
+  readonly label = input<string>("Slider");
+}

--- a/test-workspace/projects/test-ui-kit/tabs/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/tabs/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/tabs/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/tabs/public-api.ts
@@ -1,1 +1,1 @@
-export { TabsComponent } from "./tabs.component.js";
+export { TabsComponent } from './tabs.component.js';

--- a/test-workspace/projects/test-ui-kit/tabs/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/tabs/public-api.ts
@@ -1,0 +1,1 @@
+export { TabsComponent } from "./tabs.component.js";

--- a/test-workspace/projects/test-ui-kit/tabs/tabs.component.ts
+++ b/test-workspace/projects/test-ui-kit/tabs/tabs.component.ts
@@ -1,19 +1,17 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatTabsModule } from "@angular/material/tabs";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Tabs",
-  category: "Components",
-  description: "TabsComponent from test-ui-kit/tabs secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Tabs" } },
-  ],
+  title: 'Tabs',
+  category: 'Components',
+  description: 'TabsComponent from test-ui-kit/tabs secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Tabs' } }],
 })
 @Component({
-  selector: "uk-tabs",
+  selector: 'uk-tabs',
   standalone: true,
   imports: [CommonModule, MatTabsModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +19,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class TabsComponent {
-  readonly label = input<string>("Tabs");
+  readonly label = input<string>('Tabs');
 }

--- a/test-workspace/projects/test-ui-kit/tabs/tabs.component.ts
+++ b/test-workspace/projects/test-ui-kit/tabs/tabs.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatTabsModule } from "@angular/material/tabs";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Tabs",
+  category: "Components",
+  description: "TabsComponent from test-ui-kit/tabs secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Tabs" } },
+  ],
+})
+@Component({
+  selector: "uk-tabs",
+  standalone: true,
+  imports: [CommonModule, MatTabsModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class TabsComponent {
+  readonly label = input<string>("Tabs");
+}

--- a/test-workspace/projects/test-ui-kit/toolbar/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/toolbar/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/toolbar/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/toolbar/public-api.ts
@@ -1,1 +1,1 @@
-export { ToolbarComponent } from "./toolbar.component.js";
+export { ToolbarComponent } from './toolbar.component.js';

--- a/test-workspace/projects/test-ui-kit/toolbar/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/toolbar/public-api.ts
@@ -1,0 +1,1 @@
+export { ToolbarComponent } from "./toolbar.component.js";

--- a/test-workspace/projects/test-ui-kit/toolbar/toolbar.component.ts
+++ b/test-workspace/projects/test-ui-kit/toolbar/toolbar.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatToolbarModule } from "@angular/material/toolbar";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Toolbar",
+  category: "Components",
+  description: "ToolbarComponent from test-ui-kit/toolbar secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Toolbar" } },
+  ],
+})
+@Component({
+  selector: "uk-toolbar",
+  standalone: true,
+  imports: [CommonModule, MatToolbarModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class ToolbarComponent {
+  readonly label = input<string>("Toolbar");
+}

--- a/test-workspace/projects/test-ui-kit/toolbar/toolbar.component.ts
+++ b/test-workspace/projects/test-ui-kit/toolbar/toolbar.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatToolbarModule } from "@angular/material/toolbar";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Toolbar",
-  category: "Components",
-  description: "ToolbarComponent from test-ui-kit/toolbar secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Toolbar" } },
-  ],
+  title: 'Toolbar',
+  category: 'Components',
+  description:
+    'ToolbarComponent from test-ui-kit/toolbar secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Toolbar' } }],
 })
 @Component({
-  selector: "uk-toolbar",
+  selector: 'uk-toolbar',
   standalone: true,
   imports: [CommonModule, MatToolbarModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class ToolbarComponent {
-  readonly label = input<string>("Toolbar");
+  readonly label = input<string>('Toolbar');
 }

--- a/test-workspace/projects/test-ui-kit/tooltip/ng-package.json
+++ b/test-workspace/projects/test-ui-kit/tooltip/ng-package.json
@@ -1,0 +1,5 @@
+{
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/test-workspace/projects/test-ui-kit/tooltip/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/tooltip/public-api.ts
@@ -1,1 +1,1 @@
-export { TooltipComponent } from "./tooltip.component.js";
+export { TooltipComponent } from './tooltip.component.js';

--- a/test-workspace/projects/test-ui-kit/tooltip/public-api.ts
+++ b/test-workspace/projects/test-ui-kit/tooltip/public-api.ts
@@ -1,0 +1,1 @@
+export { TooltipComponent } from "./tooltip.component.js";

--- a/test-workspace/projects/test-ui-kit/tooltip/tooltip.component.ts
+++ b/test-workspace/projects/test-ui-kit/tooltip/tooltip.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, input } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { MatTooltipModule } from "@angular/material/tooltip";
+import { OverlayModule } from "@angular/cdk/overlay";
+import { Showcase } from "@ng-prism/core";
+
+@Showcase({
+  title: "Tooltip",
+  category: "Components",
+  description: "TooltipComponent from test-ui-kit/tooltip secondary entry point.",
+  variants: [
+    { name: "Default", inputs: { label: "Tooltip" } },
+  ],
+})
+@Component({
+  selector: "uk-tooltip",
+  standalone: true,
+  imports: [CommonModule, MatTooltipModule, OverlayModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<div class="uk">{{ label() }}</div>`,
+  styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
+})
+export class TooltipComponent {
+  readonly label = input<string>("Tooltip");
+}

--- a/test-workspace/projects/test-ui-kit/tooltip/tooltip.component.ts
+++ b/test-workspace/projects/test-ui-kit/tooltip/tooltip.component.ts
@@ -1,19 +1,18 @@
-import { ChangeDetectionStrategy, Component, input } from "@angular/core";
-import { CommonModule } from "@angular/common";
-import { MatTooltipModule } from "@angular/material/tooltip";
-import { OverlayModule } from "@angular/cdk/overlay";
-import { Showcase } from "@ng-prism/core";
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { Showcase } from '@ng-prism/core';
 
 @Showcase({
-  title: "Tooltip",
-  category: "Components",
-  description: "TooltipComponent from test-ui-kit/tooltip secondary entry point.",
-  variants: [
-    { name: "Default", inputs: { label: "Tooltip" } },
-  ],
+  title: 'Tooltip',
+  category: 'Components',
+  description:
+    'TooltipComponent from test-ui-kit/tooltip secondary entry point.',
+  variants: [{ name: 'Default', inputs: { label: 'Tooltip' } }],
 })
 @Component({
-  selector: "uk-tooltip",
+  selector: 'uk-tooltip',
   standalone: true,
   imports: [CommonModule, MatTooltipModule, OverlayModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -21,5 +20,5 @@ import { Showcase } from "@ng-prism/core";
   styles: `:host { display: inline-block; } .uk { padding: 8px; }`,
 })
 export class TooltipComponent {
-  readonly label = input<string>("Tooltip");
+  readonly label = input<string>('Tooltip');
 }


### PR DESCRIPTION
Fixes #8.

## Summary

After #6 the pipeline correctly discovers every secondary entry point of an ng-packagr library — but each entry was scanned by its own `ts.Program`. Every program independently parsed the full transitive type graph (`@angular/core`, `@angular/cdk`, `@angular/material`, `rxjs`, ...), so memory scaled with `N × (framework typings)`. Realistic component libraries (15-30 secondaries, Material-based) crashed the scanner with `FATAL ERROR: Ineffective mark-compacts near heap limit` on first scan.

This PR replaces the per-entry programs with **a single shared `ts.Program`** whose `rootNames` is the union of all entry-point files. Framework typings are parsed once and shared across entries via a single `TypeChecker`. The runtime manifest is byte-identical to before — this is a pure internal refactor of the scan layer.

## Bench (15-secondary × Material/CDK fixture, pipeline-only)

| Metric | Before | After | Factor |
|---|---|---|---|
| Cold scan heap delta | 2401 MB | **93 MB** | **25× lower** |
| Cold scan RSS | 2616 MB | **240 MB** | **11× lower** |
| Cold scan time | 9511 ms | **577 ms** | **16× faster** |
| Warm scan time (mean) | — | **292 ms** | sub-300ms incremental |
| Watch RSS drift (100 rebuilds) | — | **2.6%** | practically flat |
| With `--max-old-space-size=1024` | **OOM ❌** | **passes** | reporter's crash |

End-to-end `ng run test-ui-kit:prism-build` (Angular bundle included): 614 MB resident vs. 3.14 GB before.

## What changed

- **`resolveEntryPointExports`** — accepts `EntryPointInput[]`, returns one program with per-entry exports. Per-entry failure isolation: missing source files now warn and skip instead of throwing.
- **`createScanner`** — operates on multi-entry input, attaches `importPath` to each scanned component inside the scan loop, dedupes by `(filePath, className)` with a `console.warn` for re-exported duplicates.
- **`prism-pipeline`** — `PrismPipelineState` now holds `{ scanner, lastEntrySetKey }`. On rebuild, if the entry set changed (new/removed secondary), the scanner is dropped and recreated; otherwise `previousProgram` is reused for incremental scans.
- **Compiler-option diet** — `types: []`, `noEmit: true`, `skipDefaultLibCheck: true` added to `DEFAULT_COMPILER_OPTIONS` (cuts heap further on top of shared-program win).
- **Showcase pre-filter** — `sourceFile.text.includes('@Showcase')` short-circuits the decorator walk for non-Showcase files. Defensive perf win for libraries with mixed exports.

## Test plan

- [x] Full suite: **465 tests / 37 suites** green (was 460 / 37 — +5 new tests for multi-entry program sharing, importPath tagging, dedupe, per-entry failure isolation).
- [x] `npx nx build ng-prism` clean.
- [x] End-to-end `ng run test-ui-kit:prism-build` on the existing 2-secondary fixture: manifest correct, app boots.
- [x] Bench against expanded 15-Material-secondary fixture (local working tree, not committed): all targets passed.
- [x] Watch-mode steady-state bench (100 rebuilds): 2.6% RSS variation, no drift.

## Out of scope (tracked in `.claude/docs/2026-05-18-shared-ts-program-design.md`)

Follow-ups for separate iterations, in expected ROI order:
1. SourceFile-version scan cache (skip `scanComponents` on unchanged entries)
2. Discovery cache via chokidar event filter (only re-walk on `ng-package.json` changes)
3. `ts.createIncrementalProgram` + `.tsbuildinfo` (cold-start win for CI / fresh starts)
4. Plugin-hook caching
5. `NgEntryPoint` adoption (replace custom `ng-package.json` parser with ng-packagr API)