### PR TITLE
fix(scanner): preserve type alias and undefined in input rawType

### DIFF
--- a/packages/ng-prism/src/builder/scanner/__fixtures__/signal-button.component.ts
+++ b/packages/ng-prism/src/builder/scanner/__fixtures__/signal-button.component.ts
@@ -4,6 +4,8 @@ function Showcase(config: unknown): ClassDecorator {
   return () => {};
 }
 
+export type ButtonSize = 'small' | 'medium' | 'large';
+
 @Showcase({
   title: 'SignalButton',
   category: 'Inputs',
@@ -31,6 +33,9 @@ export class SignalButtonComponent {
 
   /** Tab index for keyboard navigation */
   readonly tabIndex = input<number | null>(null);
+
+  /** Optional size with explicit undefined */
+  readonly size = input<ButtonSize | undefined>(undefined);
 
   /** Click event */
   readonly clicked = output<void>();

--- a/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
+++ b/packages/ng-prism/src/builder/scanner/input.extractor.spec.ts
@@ -148,7 +148,7 @@ describe('extractInputs (signal-based)', () => {
     );
     const inputs = extractInputs(classDecl, checker);
 
-    expect(inputs).toHaveLength(5);
+    expect(inputs).toHaveLength(6);
     const names = inputs.map((i) => i.name);
     expect(names).toEqual([
       'variant',
@@ -156,6 +156,7 @@ describe('extractInputs (signal-based)', () => {
       'disabled',
       'title',
       'tabIndex',
+      'size',
     ]);
   });
 
@@ -172,6 +173,21 @@ describe('extractInputs (signal-based)', () => {
     expect(variant.values).toEqual(['primary', 'secondary', 'danger']);
     expect(variant.defaultValue).toBe('primary');
     expect(variant.required).toBe(false);
+    expect(variant.rawType).toBe("'primary' | 'secondary' | 'danger'");
+  });
+
+  it('should preserve type alias and undefined in rawType for `Alias | undefined`', () => {
+    const classDecl = getClassDeclaration(
+      exports,
+      'SignalButtonComponent',
+      checker
+    );
+    const inputs = extractInputs(classDecl, checker);
+    const size = inputs.find((i) => i.name === 'size')!;
+
+    expect(size.type).toBe('union');
+    expect(size.values).toEqual(['small', 'medium', 'large']);
+    expect(size.rawType).toBe('ButtonSize | undefined');
   });
 
   it('should infer string type from signal default value', () => {

--- a/packages/ng-prism/src/builder/scanner/input.extractor.ts
+++ b/packages/ng-prism/src/builder/scanner/input.extractor.ts
@@ -107,8 +107,9 @@ function resolveSignalInputType(
   checker: ts.TypeChecker,
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
   if (callExpr.typeArguments && callExpr.typeArguments.length > 0) {
-    const resolved = checker.getTypeFromTypeNode(callExpr.typeArguments[0]);
-    return mapType(resolved, checker);
+    const typeNode = callExpr.typeArguments[0];
+    const resolved = checker.getTypeFromTypeNode(typeNode);
+    return mapType(resolved, checker, normalizeTypeText(typeNode.getText()));
   }
 
   if (callExpr.arguments.length > 0) {
@@ -140,7 +141,12 @@ function resolveDecoratorInputType(
   checker: ts.TypeChecker,
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
   const tsType = checker.getTypeAtLocation(member);
-  return mapType(tsType, checker);
+  const declaredText = member.type ? normalizeTypeText(member.type.getText()) : undefined;
+  return mapType(tsType, checker, declaredText);
+}
+
+function normalizeTypeText(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
 }
 
 function getRawTypeLabel(tsType: ts.Type, checker: ts.TypeChecker): string {
@@ -164,8 +170,9 @@ function getRawTypeLabel(tsType: ts.Type, checker: ts.TypeChecker): string {
 function mapType(
   tsType: ts.Type,
   checker: ts.TypeChecker,
+  rawTypeOverride?: string,
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
-  const rawType = getRawTypeLabel(tsType, checker);
+  const rawType = rawTypeOverride ?? getRawTypeLabel(tsType, checker);
 
   if (tsType.flags & ts.TypeFlags.BooleanLike) {
     return { type: 'boolean', rawType };

--- a/packages/ng-prism/src/builder/scanner/input.extractor.ts
+++ b/packages/ng-prism/src/builder/scanner/input.extractor.ts
@@ -1,38 +1,74 @@
 import ts from 'typescript';
 import type { InputMeta, OutputMeta } from '../../plugin/plugin.types.js';
-import { evaluateExpression, findDecorator, getDecoratorArgument, getJsDocComment } from './ast-utils.js';
+import {
+  evaluateExpression,
+  findDecorator,
+  getDecoratorArgument,
+  getJsDocComment,
+} from './ast-utils.js';
 
 /**
  * Extract all @Input(), input() and model() signal metadata from a class declaration.
  */
-export function extractInputs(classDecl: ts.ClassDeclaration, checker: ts.TypeChecker): InputMeta[] {
+export function extractInputs(
+  classDecl: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+): InputMeta[] {
   const inputs: InputMeta[] = [];
 
   for (const member of classDecl.members) {
     if (!ts.isPropertyDeclaration(member)) continue;
 
-    const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+    const name =
+      member.name && ts.isIdentifier(member.name)
+        ? member.name.text
+        : undefined;
     if (!name) continue;
 
     const inputDecorator = findDecorator(member, 'Input');
     if (inputDecorator) {
       const required = isDecoratorInputRequired(inputDecorator);
-      const defaultValue = member.initializer ? evaluateExpression(member.initializer) : undefined;
+      const defaultValue = member.initializer
+        ? evaluateExpression(member.initializer)
+        : undefined;
       const doc = getJsDocComment(member, checker);
-      const { type, values, rawType } = resolveDecoratorInputType(member, checker);
-      inputs.push({ name, type, rawType, required, ...(values && { values }), ...(defaultValue !== undefined && { defaultValue }), ...(doc && { doc }) });
+      const { type, values, rawType } = resolveDecoratorInputType(
+        member,
+        checker
+      );
+      inputs.push({
+        name,
+        type,
+        rawType,
+        required,
+        ...(values && { values }),
+        ...(defaultValue !== undefined && { defaultValue }),
+        ...(doc && { doc }),
+      });
       continue;
     }
 
     const signalCall = getInputSignalCall(member);
     if (signalCall) {
       const required = isSignalInputRequired(signalCall);
-      const defaultValue = !required && signalCall.arguments.length > 0
-        ? evaluateExpression(signalCall.arguments[0])
-        : undefined;
+      const defaultValue =
+        !required && signalCall.arguments.length > 0
+          ? evaluateExpression(signalCall.arguments[0])
+          : undefined;
       const doc = getJsDocComment(member, checker);
-      const { type, values, rawType } = resolveSignalInputType(signalCall, checker);
-      inputs.push({ name, type, rawType, required, ...(values && { values }), ...(defaultValue !== undefined && { defaultValue }), ...(doc && { doc }) });
+      const { type, values, rawType } = resolveSignalInputType(
+        signalCall,
+        checker
+      );
+      inputs.push({
+        name,
+        type,
+        rawType,
+        required,
+        ...(values && { values }),
+        ...(defaultValue !== undefined && { defaultValue }),
+        ...(doc && { doc }),
+      });
     }
   }
 
@@ -42,13 +78,19 @@ export function extractInputs(classDecl: ts.ClassDeclaration, checker: ts.TypeCh
 /**
  * Extract all @Output() and output() signal metadata from a class declaration.
  */
-export function extractOutputs(classDecl: ts.ClassDeclaration, checker: ts.TypeChecker): OutputMeta[] {
+export function extractOutputs(
+  classDecl: ts.ClassDeclaration,
+  checker: ts.TypeChecker
+): OutputMeta[] {
   const outputs: OutputMeta[] = [];
 
   for (const member of classDecl.members) {
     if (!ts.isPropertyDeclaration(member)) continue;
 
-    const name = member.name && ts.isIdentifier(member.name) ? member.name.text : undefined;
+    const name =
+      member.name && ts.isIdentifier(member.name)
+        ? member.name.text
+        : undefined;
     if (!name) continue;
 
     const outputDecorator = findDecorator(member, 'Output');
@@ -67,18 +109,23 @@ export function extractOutputs(classDecl: ts.ClassDeclaration, checker: ts.TypeC
   return outputs;
 }
 
-function getInputSignalCall(member: ts.PropertyDeclaration): ts.CallExpression | null {
+function getInputSignalCall(
+  member: ts.PropertyDeclaration
+): ts.CallExpression | null {
   const init = member.initializer;
   if (!init || !ts.isCallExpression(init)) return null;
 
   const expr = init.expression;
 
-  if (ts.isIdentifier(expr) && (expr.text === 'input' || expr.text === 'model')) return init;
+  if (ts.isIdentifier(expr) && (expr.text === 'input' || expr.text === 'model'))
+    return init;
 
   if (
     ts.isPropertyAccessExpression(expr) &&
-    ts.isIdentifier(expr.expression) && (expr.expression.text === 'input' || expr.expression.text === 'model') &&
-    ts.isIdentifier(expr.name) && expr.name.text === 'required'
+    ts.isIdentifier(expr.expression) &&
+    (expr.expression.text === 'input' || expr.expression.text === 'model') &&
+    ts.isIdentifier(expr.name) &&
+    expr.name.text === 'required'
   ) {
     return init;
   }
@@ -104,7 +151,7 @@ function isOutputSignal(member: ts.PropertyDeclaration): boolean {
 
 function resolveSignalInputType(
   callExpr: ts.CallExpression,
-  checker: ts.TypeChecker,
+  checker: ts.TypeChecker
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
   if (callExpr.typeArguments && callExpr.typeArguments.length > 0) {
     const typeNode = callExpr.typeArguments[0];
@@ -138,10 +185,12 @@ function isDecoratorInputRequired(decorator: ts.Decorator): boolean {
 
 function resolveDecoratorInputType(
   member: ts.PropertyDeclaration,
-  checker: ts.TypeChecker,
+  checker: ts.TypeChecker
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
   const tsType = checker.getTypeAtLocation(member);
-  const declaredText = member.type ? normalizeTypeText(member.type.getText()) : undefined;
+  const declaredText = member.type
+    ? normalizeTypeText(member.type.getText())
+    : undefined;
   return mapType(tsType, checker, declaredText);
 }
 
@@ -150,16 +199,23 @@ function normalizeTypeText(text: string): string {
 }
 
 function getRawTypeLabel(tsType: ts.Type, checker: ts.TypeChecker): string {
-  if (tsType.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLike | ts.TypeFlags.BooleanLiteral)) {
+  if (
+    tsType.flags &
+    (ts.TypeFlags.Boolean |
+      ts.TypeFlags.BooleanLike |
+      ts.TypeFlags.BooleanLiteral)
+  ) {
     return 'boolean';
   }
 
   if (tsType.isUnion()) {
     const meaningful = tsType.types.filter(
-      (t) => !(t.flags & ts.TypeFlags.Undefined) && !(t.flags & ts.TypeFlags.Null),
+      (t) =>
+        !(t.flags & ts.TypeFlags.Undefined) && !(t.flags & ts.TypeFlags.Null)
     );
     if (meaningful.length === 0) return checker.typeToString(tsType);
-    if (meaningful.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) return 'boolean';
+    if (meaningful.every((t) => t.flags & ts.TypeFlags.BooleanLiteral))
+      return 'boolean';
     if (meaningful.length === 1) return checker.typeToString(meaningful[0]);
     if (tsType.aliasSymbol) return tsType.aliasSymbol.getName();
     return meaningful.map((t) => checker.typeToString(t)).join(' | ');
@@ -170,7 +226,7 @@ function getRawTypeLabel(tsType: ts.Type, checker: ts.TypeChecker): string {
 function mapType(
   tsType: ts.Type,
   checker: ts.TypeChecker,
-  rawTypeOverride?: string,
+  rawTypeOverride?: string
 ): { type: InputMeta['type']; values?: string[]; rawType: string } {
   const rawType = rawTypeOverride ?? getRawTypeLabel(tsType, checker);
 
@@ -184,8 +240,7 @@ function mapType(
   if (tsType.isUnion()) {
     const filtered = tsType.types.filter(
       (t) =>
-        !(t.flags & ts.TypeFlags.Undefined) &&
-        !(t.flags & ts.TypeFlags.Null),
+        !(t.flags & ts.TypeFlags.Undefined) && !(t.flags & ts.TypeFlags.Null)
     );
 
     if (filtered.every((t) => t.flags & ts.TypeFlags.BooleanLiteral)) {


### PR DESCRIPTION
Closes #17

## Summary
- Use the original `TypeNode` source text for the `rawType` label when an explicit type argument exists (signal inputs via `callExpr.typeArguments[0]`, decorator inputs via `member.type`)
- Resolved `ts.Type` is still used for the `type` discriminator and dropdown `values` — control behavior is unchanged
- Fixes `input<Alias | undefined>(undefined)` losing both the alias and `undefined` in the controls panel (e.g. `sg-ui-lib` Pill's `hoverTint`)

## Test plan
- [x] `npx nx test ng-prism` — 545 tests pass
- [x] New regression test `should preserve type alias and undefined in rawType for \`Alias | undefined\``
- [x] Existing `should resolve union type from signal type argument` extended to assert `rawType`
- [ ] Manual: rebuild `ng-prism`, regenerate `sg-ui-lib` prism manifest, verify `hoverTint` label now reads `SguiPillTintType | undefined`